### PR TITLE
Fix numpy_extensions_tutorial.py

### DIFF
--- a/advanced_source/numpy_extensions_tutorial.py
+++ b/advanced_source/numpy_extensions_tutorial.py
@@ -103,7 +103,7 @@ class ScipyConv2dFunction(Function):
         # the previous line can be expressed equivalently as:
         # grad_input = correlate2d(grad_output, flip(flip(filter.numpy(), axis=0), axis=1), mode='full')
         grad_filter = correlate2d(input.numpy(), grad_output, mode='valid')
-        return torch.from_numpy(grad_input), torch.from_numpy(grad_filter), torch.from_numpy(grad_bias)
+        return torch.from_numpy(grad_input), torch.from_numpy(grad_filter).to(torch.float), torch.from_numpy(grad_bias).to(torch.float)
 
 
 class ScipyConv2d(Module):


### PR DESCRIPTION
Currently it gives this error: 
```
06:36:32 Exception occurred:
06:36:32   File "/opt/conda/lib/python3.6/site-packages/sphinx_gallery/gen_gallery.py", line 313, in sumarize_failing_examples
06:36:32     "\n" + "-" * 79)
06:36:32 ValueError: Here is a summary of the problems encountered when running the examples
06:36:32 
06:36:32 Unexpected failing examples:
06:36:32 /var/lib/jenkins/workspace/tutorials_repo/advanced_source/numpy_extensions_tutorial.py failed leaving traceback:
06:36:32 Traceback (most recent call last):
06:36:32   File "/var/lib/jenkins/workspace/tutorials_repo/advanced_source/numpy_extensions_tutorial.py", line 138, in <module>
06:36:32     test = gradcheck(moduleConv, input, eps=1e-6, atol=1e-4)
06:36:32   File "/opt/conda/lib/python3.6/site-packages/torch/autograd/gradcheck.py", line 204, in gradcheck
06:36:32     analytical, reentrant, correct_grad_sizes = get_analytical_jacobian(tupled_inputs, o)
06:36:32   File "/opt/conda/lib/python3.6/site-packages/torch/autograd/gradcheck.py", line 96, in get_analytical_jacobian
06:36:32     retain_graph=True, allow_unused=True)
06:36:32   File "/opt/conda/lib/python3.6/site-packages/torch/autograd/__init__.py", line 145, in grad
06:36:32     inputs, allow_unused)
06:36:32 RuntimeError: Function ScipyConv2dFunctionBackward returned an invalid gradient at index 1 - expected type torch.FloatTensor but got torch.DoubleTensor
```